### PR TITLE
Recent pkgin can show several extra lines before the "nothing to do"

### DIFF
--- a/plugins/modules/packaging/os/pkgin.py
+++ b/plugins/modules/packaging/os/pkgin.py
@@ -309,7 +309,7 @@ def do_upgrade_packages(module, full=False):
         format_pkgin_command(module, cmd))
 
     if rc == 0:
-        if re.search('^nothing to do.\n$', out):
+        if re.search('^(.*\n|)nothing to do.\n$', out):
             module.exit_json(changed=False, msg="nothing left to upgrade")
     else:
         module.fail_json(msg="could not %s packages" % cmd)


### PR DESCRIPTION
Recent pkgin can show several extra lines before the "nothing to do". For example: ```calculating dependencies...done.``` or ```downloading pkg_summary.xz done.```.

The proposed change eats all content and just verify that the last line is "nothing to do". Previous lines are ignored.